### PR TITLE
👔 (api): Add queue to process matchs and bans event

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { BansModule } from "./bans/bans.module";
 import { ConfigsModule } from "./configs/configs.module";
 import { FirewallModule } from "./firewall/firewall.module";
 import { MatchesModule } from "./matches/matches.module";
+import { SharedModule } from "./shared/shared.module";
 import { StatsModule } from "./stats/stats.module";
 import { UnbansModule } from "./unbans/unbans.module";
 import { WatchersModule } from "./watchers/watchers.module";
@@ -17,6 +18,7 @@ import { WatchersModule } from "./watchers/watchers.module";
     MongooseModule.forRoot(process.env.BANALIZE_API_MONGO_URI),
     EventEmitterModule.forRoot(),
     ScheduleModule.forRoot(),
+    SharedModule,
     ConfigsModule,
     MatchesModule,
     WatchersModule,

--- a/apps/api/src/bans/bans.module.ts
+++ b/apps/api/src/bans/bans.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
+import { SharedModule } from "src/shared/shared.module";
 import { BansController } from "./bans.controller";
 import { BansService } from "./bans.service";
 import { BanSchema, BanSchemaDefinition } from "./schemas/ban.schema";
@@ -11,6 +12,7 @@ import { BanEventHandlerService } from "./services/ban-event-handler.service";
     MongooseModule.forFeature([
       { name: BanSchema.name, schema: BanSchemaDefinition },
     ]),
+    SharedModule,
   ],
   controllers: [BansController],
   providers: [BansService, BanEventHandlerService, BanCleanupService],

--- a/apps/api/src/matches/matches.module.ts
+++ b/apps/api/src/matches/matches.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
+import { SharedModule } from "src/shared/shared.module";
 import { MatchesController } from "./matches.controller";
 import { MatchSchema, MatchSchemaDefinition } from "./schemas/match.schema";
 import { MatchEventHandlerService } from "./services/match-event-handler.service";
@@ -10,6 +11,7 @@ import { MatchesService } from "./services/matches.service";
     MongooseModule.forFeature([
       { name: MatchSchema.name, schema: MatchSchemaDefinition },
     ]),
+    SharedModule,
   ],
   controllers: [MatchesController],
   providers: [MatchEventHandlerService, MatchesService],

--- a/apps/api/src/shared/enums/priority.enum.ts
+++ b/apps/api/src/shared/enums/priority.enum.ts
@@ -1,0 +1,5 @@
+export enum QueuePriority {
+  HIGH = 1,
+  MEDIUM = 2,
+  LOW = 3,
+}

--- a/apps/api/src/shared/services/queue.service.ts
+++ b/apps/api/src/shared/services/queue.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from "@nestjs/common";
+import { QueuePriority } from "src/shared/enums/priority.enum";
+
+type EventQueueItemData<EventType> = EventType;
+type EventQueueItemHandler<EventType> = (event: EventType) => Promise<void>;
+
+interface EventQueueItem<EventType> {
+  data: EventQueueItemData<EventType>;
+  handler: EventQueueItemHandler<EventType>;
+  priority: QueuePriority;
+}
+
+@Injectable()
+export class QueueService {
+  private queue: EventQueueItem<unknown>[] = [];
+  private processing = false;
+
+  enqueue<EventType>(
+    data: EventQueueItemData<EventType>,
+    handler: EventQueueItemHandler<EventType>,
+    priority: QueuePriority,
+  ) {
+    this.queue.push({ handler, priority, data });
+    this.queue.sort((a, b) => a.priority - b.priority);
+    this.processQueue();
+  }
+
+  private async processQueue() {
+    if (this.processing) return;
+
+    const nextItem = this.queue.shift();
+    if (!nextItem) return;
+
+    this.processing = true;
+
+    try {
+      await nextItem.handler(nextItem.data);
+    } finally {
+      this.processing = false;
+      if (this.queue.length > 0) {
+        this.processQueue();
+      }
+    }
+  }
+}

--- a/apps/api/src/shared/shared.module.ts
+++ b/apps/api/src/shared/shared.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { QueueService } from "./services/queue.service";
+
+@Module({
+  providers: [QueueService],
+  exports: [QueueService],
+})
+export class SharedModule {}

--- a/apps/api/src/watchers/services/docker-watcher.service.ts
+++ b/apps/api/src/watchers/services/docker-watcher.service.ts
@@ -61,7 +61,7 @@ export class DockerWatcherService implements Watcher {
     this.status = Status.STOPPED;
   };
 
-  private onData = async (chunk: Buffer) => {
+  private onData = (chunk: Buffer) => {
     const lines = chunk.toString().split("\n");
 
     for (const line of lines) {
@@ -71,7 +71,7 @@ export class DockerWatcherService implements Watcher {
         if (ip && !this.config.ignoreIps.includes(ip)) {
           this.logger.debug("Matched line");
 
-          await this.eventEmitter.emitAsync(
+          this.eventEmitter.emit(
             Events.MATCH_CREATION_REQUESTED,
             new MatchEvent(line, ip, this.config),
           );

--- a/apps/api/src/watchers/services/file-watcher.service.ts
+++ b/apps/api/src/watchers/services/file-watcher.service.ts
@@ -69,7 +69,7 @@ export class FileWatcherService implements Watcher {
     this.status = Status.STOPPED;
   };
 
-  private onData = async (chunk: Buffer) => {
+  private onData = (chunk: Buffer) => {
     const lines = chunk.toString().split("\n");
 
     for (const line of lines) {
@@ -79,7 +79,7 @@ export class FileWatcherService implements Watcher {
         if (ip && !this.config.ignoreIps.includes(ip)) {
           this.logger.debug("Matched line");
 
-          await this.eventEmitter.emitAsync(
+          this.eventEmitter.emit(
             Events.MATCH_CREATION_REQUESTED,
             new MatchEvent(line, ip, this.config),
           );


### PR DESCRIPTION
This PR improve the way events are handled.
For matches and bans creation, we need to process event synchronously, with a priority to bans events, to be able to detect and ban a malicious actor really quickly.