### PR TITLE
✨ (api): implement cidr on ignoreIps

### DIFF
--- a/apps/api/src/configs/dtos/config-creation-dto.ts
+++ b/apps/api/src/configs/dtos/config-creation-dto.ts
@@ -76,7 +76,7 @@ export class ConfigCreationDto implements ConfigCreation {
   @IsCidrOrIp()
   @IsOptional()
   @ApiProperty({
-    example: ["192.168.1.1", "192.168.1.0/32"],
+    example: ["192.168.1.1", "192.168.1.0/24"],
     description: "the list of IPs to ignore",
     required: false,
   })

--- a/apps/api/src/configs/dtos/config-creation-dto.ts
+++ b/apps/api/src/configs/dtos/config-creation-dto.ts
@@ -7,13 +7,13 @@ import {
   Contains,
   IsArray,
   IsIn,
-  IsIP,
   IsNotEmpty,
   IsOptional,
   IsPositive,
   IsString,
 } from "class-validator";
 import { IsRegex } from "src/configs/utils/is-regex-validator";
+import { IsCidrOrIp } from "src/configs/utils/is-cidr-or-ip-validator";
 
 export class ConfigCreationDto implements ConfigCreation {
   @IsString()
@@ -73,10 +73,10 @@ export class ConfigCreationDto implements ConfigCreation {
 
   @IsArray()
   @IsString({ each: true })
-  @IsIP("4", { each: true })
+  @IsCidrOrIp()
   @IsOptional()
   @ApiProperty({
-    example: ["192.168.1.1"],
+    example: ["192.168.1.1", "192.168.1.0/32"],
     description: "the list of IPs to ignore",
     required: false,
   })

--- a/apps/api/src/configs/dtos/config-creation-dto.ts
+++ b/apps/api/src/configs/dtos/config-creation-dto.ts
@@ -12,8 +12,8 @@ import {
   IsPositive,
   IsString,
 } from "class-validator";
-import { IsRegex } from "src/configs/utils/is-regex-validator";
 import { IsCidrOrIp } from "src/configs/utils/is-cidr-or-ip-validator";
+import { IsRegex } from "src/configs/utils/is-regex-validator";
 
 export class ConfigCreationDto implements ConfigCreation {
   @IsString()

--- a/apps/api/src/configs/utils/is-cidr-or-ip-validator.spec.ts
+++ b/apps/api/src/configs/utils/is-cidr-or-ip-validator.spec.ts
@@ -33,13 +33,13 @@ describe("IsCidrOrIp", () => {
 
   it("should reject invalid IP addresses", async () => {
     const invalidIPs = [
-      ["256.1.2.3"], // Octet > 255
-      ["1.2.3.256"], // Octet > 255
-      ["1.2.3"], // Octet is missing
-      ["1.2.3.4.5"], // Too many octets
-      ["abc.def.ghi.jkl"], // Non-numeric octets
-      ["192.168.1."], // incomplete IP
-      [".192.168.1"], // Ip badly formatted
+      ["256.1.2.3"],
+      ["1.2.3.256"],
+      ["1.2.3"],
+      ["1.2.3.4.5"],
+      ["abc.def.ghi.jkl"],
+      ["192.168.1."],
+      [".192.168.1"],
     ];
 
     for (const ips of invalidIPs) {
@@ -51,12 +51,12 @@ describe("IsCidrOrIp", () => {
 
   it("should reject invalid CIDR notations", async () => {
     const invalidCIDRs = [
-      ["192.168.1.0/33"], // Masque > 32
-      ["192.168.1.0/-1"], // Masque négatif
-      ["192.168.1.0/"], // Masque manquant
-      ["192.168.1/24"], // IP incomplète
-      ["192.168.1.0.0/24"], // IP mal formatée
-      ["256.168.1.0/24"], // Octet > 255
+      ["192.168.1.0/33"],
+      ["192.168.1.0/-1"],
+      ["192.168.1.0/"],
+      ["192.168.1/24"],
+      ["192.168.1.0.0/24"],
+      ["256.168.1.0/24"],
     ];
 
     for (const cidrs of invalidCIDRs) {
@@ -67,7 +67,7 @@ describe("IsCidrOrIp", () => {
   });
 
   it("should reject if not an array", async () => {
-    // @ts-expect-error - Test intentionnel avec un type invalide
+    // @ts-expect-error - intentionally passing a string
     test.ipList = "192.168.1.1";
     const errors = await validate(test);
     expect(errors).toHaveLength(1);

--- a/apps/api/src/configs/utils/is-cidr-or-ip-validator.spec.ts
+++ b/apps/api/src/configs/utils/is-cidr-or-ip-validator.spec.ts
@@ -1,0 +1,99 @@
+import { validate } from "class-validator";
+import { IsCidrOrIp } from "./is-cidr-or-ip-validator";
+
+class TestClass {
+  @IsCidrOrIp()
+  ipList: string[];
+}
+
+describe("IsCidrOrIp", () => {
+  let test: TestClass;
+
+  beforeEach(() => {
+    test = new TestClass();
+  });
+
+  it("should validate valid IP addresses", async () => {
+    test.ipList = ["192.168.1.1", "10.0.0.1", "172.16.0.1"];
+    const errors = await validate(test);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should validate valid CIDR notations", async () => {
+    test.ipList = ["192.168.1.0/24", "10.0.0.0/8", "172.16.0.0/16"];
+    const errors = await validate(test);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should validate mix of IPs and CIDR notations", async () => {
+    test.ipList = ["192.168.1.1", "10.0.0.0/8", "172.16.0.1"];
+    const errors = await validate(test);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should reject invalid IP addresses", async () => {
+    const invalidIPs = [
+      ["256.1.2.3"], // Octet > 255
+      ["1.2.3.256"], // Octet > 255
+      ["1.2.3"], // Octet is missing
+      ["1.2.3.4.5"], // Too many octets
+      ["abc.def.ghi.jkl"], // Non-numeric octets
+      ["192.168.1."], // incomplete IP
+      [".192.168.1"], // Ip badly formatted
+    ];
+
+    for (const ips of invalidIPs) {
+      test.ipList = ips;
+      const errors = await validate(test);
+      expect(errors).toHaveLength(1);
+    }
+  });
+
+  it("should reject invalid CIDR notations", async () => {
+    const invalidCIDRs = [
+      ["192.168.1.0/33"], // Masque > 32
+      ["192.168.1.0/-1"], // Masque négatif
+      ["192.168.1.0/"], // Masque manquant
+      ["192.168.1/24"], // IP incomplète
+      ["192.168.1.0.0/24"], // IP mal formatée
+      ["256.168.1.0/24"], // Octet > 255
+    ];
+
+    for (const cidrs of invalidCIDRs) {
+      test.ipList = cidrs;
+      const errors = await validate(test);
+      expect(errors).toHaveLength(1);
+    }
+  });
+
+  it("should reject if not an array", async () => {
+    // @ts-expect-error - Test intentionnel avec un type invalide
+    test.ipList = "192.168.1.1";
+    const errors = await validate(test);
+    expect(errors).toHaveLength(1);
+  });
+
+  it("should handle mixed valid and invalid entries", async () => {
+    test.ipList = ["192.168.1.1", "256.256.256.256", "10.0.0.0/8"];
+    const errors = await validate(test);
+    expect(errors).toHaveLength(1);
+  });
+
+  it("should validate all border cases for valid IPs", async () => {
+    test.ipList = ["0.0.0.0", "255.255.255.255", "192.168.0.1", "1.2.3.4"];
+    const errors = await validate(test);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("should validate all border cases for valid CIDRs", async () => {
+    test.ipList = [
+      "0.0.0.0/0",
+      "192.168.1.0/32",
+      "10.0.0.0/8",
+      "172.16.0.0/16",
+      "192.168.1.0/24",
+    ];
+    const errors = await validate(test);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/apps/api/src/configs/utils/is-cidr-or-ip-validator.ts
+++ b/apps/api/src/configs/utils/is-cidr-or-ip-validator.ts
@@ -1,0 +1,50 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from "class-validator";
+
+export function IsCidrOrIp(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: "isCidrOrIp",
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: string) {
+          if (!Array.isArray(value)) return false;
+
+          return value.every((item: string) => {
+            const ipRegex = /^(\d{1,3}\.){3}\d{1,3}$/;
+            const cidrRegex = /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}$/;
+
+            if (!ipRegex.test(item) && !cidrRegex.test(item)) {
+              return false;
+            }
+            const parts = item.split("/")[0].split(".");
+            if (
+              !parts.every((part) => {
+                const num = parseInt(part);
+                return num >= 0 && num <= 255;
+              })
+            ) {
+              return false;
+            }
+            if (cidrRegex.test(item)) {
+              const cidr = parseInt(item.split("/")[1]);
+              if (cidr < 0 || cidr > 32) {
+                return false;
+              }
+            }
+
+            return true;
+          });
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must contain valid IPv4 addresses or CIDR notation networks`;
+        },
+      },
+    });
+  };
+}

--- a/apps/api/src/matches/services/match-event-handler.service.ts
+++ b/apps/api/src/matches/services/match-event-handler.service.ts
@@ -78,9 +78,9 @@ export class MatchEventHandlerService {
 // 1         = 1 * 2⁰
 
 export function ipToLong(ip: string): number {
-  const [octet1, octet2, octet3, octet4] = ip.split(".").map(Number);
+  const [byte1, byte2, byte3, byte4] = ip.split(".").map(Number);
 
-  return ((octet1 << 24) + (octet2 << 16) + (octet3 << 8) + octet4) >>> 0;
+  return ((byte1 << 24) + (byte2 << 16) + (byte3 << 8) + byte4) >>> 0;
 }
 
 export function isIpInCidr(ip: string, cidr: string): boolean {

--- a/apps/api/src/matches/services/match-event-handler.service.ts
+++ b/apps/api/src/matches/services/match-event-handler.service.ts
@@ -32,7 +32,7 @@ export class MatchEventHandlerService {
       `Matched line: ${line}, ip: ${ip}, config: ${config.param}`,
     );
 
-    const ignored = config.ignoreIps.includes(ip);
+    const ignored = isIpInList(ip, config.ignoreIps);
     const timestamp = new Date().getTime();
 
     await this.matchesService.create({
@@ -68,4 +68,36 @@ export class MatchEventHandlerService {
 
     this.eventEmitter.emit(Events.MATCH_CREATION_DONE, event);
   };
+}
+
+// example
+// IP "192.168.1.1"
+// 192 << 24 = 192 * 2²⁴
+// 168 << 16 = 168 * 2¹⁶
+// 1 << 8    = 1 * 2⁸
+// 1         = 1 * 2⁰
+
+export function ipToLong(ip: string): number {
+  const [octet1, octet2, octet3, octet4] = ip.split(".").map(Number);
+
+  return ((octet1 << 24) + (octet2 << 16) + (octet3 << 8) + octet4) >>> 0;
+}
+
+export function isIpInCidr(ip: string, cidr: string): boolean {
+  const [network, bits = "32"] = cidr.split("/");
+  const mask = ~((1 << (32 - parseInt(bits))) - 1);
+
+  const ipLong = ipToLong(ip);
+  const networkLong = ipToLong(network);
+
+  return (ipLong & mask) === (networkLong & mask);
+}
+
+export function isIpInList(ip: string, ignoreList: string[]): boolean {
+  return ignoreList.some((ignore) => {
+    if (ignore.includes("/")) {
+      return isIpInCidr(ip, ignore);
+    }
+    return ip === ignore;
+  });
 }


### PR DESCRIPTION
Support CIDR notation on ingoreIps 

- Add support for network masks in ignoreIps config
- Replace ipToLong and isIpInCidr functions 