### PR TITLE
✨ (api): Enrich ban notifications with detailed context

### DIFF
--- a/apps/api/src/bans/types/ban-event.types.ts
+++ b/apps/api/src/bans/types/ban-event.types.ts
@@ -4,5 +4,7 @@ export class BanEvent {
   constructor(
     public readonly ip: string,
     public readonly config: ConfigSchema,
+    public readonly line?: string,
+    public readonly matchCount?: number,
   ) {}
 }

--- a/apps/api/src/ip-infos/ip-infos.module.ts
+++ b/apps/api/src/ip-infos/ip-infos.module.ts
@@ -6,5 +6,6 @@ import { IpInfosService } from "./services/ip-infos.service";
   imports: [],
   controllers: [IpInfosController],
   providers: [IpInfosService],
+  exports: [IpInfosService],
 })
 export class IpInfosModule {}

--- a/apps/api/src/matches/services/match-event-handler.service.ts
+++ b/apps/api/src/matches/services/match-event-handler.service.ts
@@ -159,6 +159,7 @@ export class MatchEventHandlerService implements OnModuleInit {
     }
 
     if (banned) {
+      const totalCount = this.matchesCache[config._id]?.[ip]?.length ?? 0;
       this.logger.warn(`Requesting ban creation for IP ${ip}`);
       this.eventEmitter.emit(
         Events.BAN_CREATION_REQUESTED,

--- a/apps/api/src/matches/services/match-event-handler.service.ts
+++ b/apps/api/src/matches/services/match-event-handler.service.ts
@@ -162,7 +162,7 @@ export class MatchEventHandlerService implements OnModuleInit {
       this.logger.warn(`Requesting ban creation for IP ${ip}`);
       this.eventEmitter.emit(
         Events.BAN_CREATION_REQUESTED,
-        new BanEvent(ip, config),
+        new BanEvent(ip, config, line, totalCount),
       );
     }
 

--- a/apps/api/src/notifications/interfaces/notification.interface.ts
+++ b/apps/api/src/notifications/interfaces/notification.interface.ts
@@ -2,5 +2,6 @@ export class Notification {
   constructor(
     public readonly title: string,
     public readonly message: string,
+    public readonly html?: string,
   ) {}
 }

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
+import { IpInfosModule } from "src/ip-infos/ip-infos.module";
 import { SharedModule } from "src/shared/shared.module";
 import { NotificationsController } from "./notifications.controller";
 import { NotifierFactory } from "./notifier-factory";
@@ -14,6 +15,7 @@ import { NotifierTestService } from "./services/notifier-test-service.service";
 
 @Module({
   imports: [
+    IpInfosModule,
     MongooseModule.forFeature([
       {
         name: NotifierConfigSchema.name,

--- a/apps/api/src/notifications/services/email-notifier.service.ts
+++ b/apps/api/src/notifications/services/email-notifier.service.ts
@@ -13,7 +13,7 @@ export class EmailNotifierService implements Notifier {
     );
   }
 
-  async notify({ message, title }: Notification): Promise<boolean> {
+  async notify({ message, title, html }: Notification): Promise<boolean> {
     this.logger.debug(`EmailNotifierService: ${message}`);
     const { username, password, port, server, recipientEmail } =
       this.config.emailConfig;
@@ -34,6 +34,7 @@ export class EmailNotifierService implements Notifier {
         to: recipientEmail,
         subject: title,
         text: message,
+        html: html ?? undefined,
       });
       return true;
     } catch (_) {

--- a/apps/api/src/notifications/services/notifier-event-handler.service.ts
+++ b/apps/api/src/notifications/services/notifier-event-handler.service.ts
@@ -1,7 +1,9 @@
-import { EventType } from "@banalize/types";
+import { EventType, IpInfosResponse } from "@banalize/types";
 import { Injectable } from "@nestjs/common";
 import { EventEmitter2, OnEvent } from "@nestjs/event-emitter";
 import { BanEvent } from "src/bans/types/ban-event.types";
+import { IpInfosService } from "src/ip-infos/services/ip-infos.service";
+import { MatchEvent } from "src/matches/types/match-event.types";
 import { Events } from "src/shared/enums/events.enum";
 import { QueuePriority } from "src/shared/enums/priority.enum";
 import { QueueService } from "src/shared/services/queue.service";
@@ -12,6 +14,7 @@ export class NotifierEventHandlerService {
   constructor(
     private readonly eventEmitter: EventEmitter2,
     private readonly queueService: QueueService,
+    private readonly ipInfosService: IpInfosService,
   ) {}
 
   @OnEvent(Events.BAN_CREATION_DONE)
@@ -24,29 +27,129 @@ export class NotifierEventHandlerService {
   }
 
   async notifyBan(banEvent: BanEvent) {
+    const { ip } = banEvent;
+
+    const geoInfo = await this.ipInfosService.findOne(ip);
+
+    const textMessage = this.buildTextMessage(banEvent, geoInfo);
+    const htmlMessage = this.buildHtmlMessage(banEvent, geoInfo);
+
     const notifyEvent = new NotifyEvent(
       EventType.BAN,
-      "Banalize: Ban created",
-      `[${banEvent.config.name}] New ban for IP ${banEvent.ip}`,
+      "Banalize: IP Banned",
+      textMessage,
+      htmlMessage,
     );
     this.eventEmitter.emit(Events.NOTIFY, notifyEvent);
   }
 
   @OnEvent(Events.MATCH_CREATION_DONE)
-  async handleMatchCreationDone(banEvent: BanEvent) {
-    this.queueService.enqueue<BanEvent>(
-      banEvent,
+  async handleMatchCreationDone(matchEvent: MatchEvent) {
+    this.queueService.enqueue<MatchEvent>(
+      matchEvent,
       this.notifyMatch.bind(this),
       QueuePriority.VERY_LOW,
     );
   }
 
-  async notifyMatch(banEvent: BanEvent) {
+  async notifyMatch(matchEvent: MatchEvent) {
     const notifyEvent = new NotifyEvent(
       EventType.MATCH,
       "Banalize: Match found",
-      `[${banEvent.config.name}] New match for IP ${banEvent.ip}`,
+      `[${matchEvent.config.name}] New match for IP ${matchEvent.ip}`,
     );
     this.eventEmitter.emit(Events.NOTIFY, notifyEvent);
+  }
+
+  private buildTextMessage(
+    event: BanEvent,
+    geo: Partial<IpInfosResponse>,
+  ): string {
+    const lines = [`[${event.config.name}] New ban`, `IP: ${event.ip}`];
+
+    if (geo?.country) {
+      lines.push(`Country: ${geo.country.flag} ${geo.country.name}`);
+    }
+
+    lines.push(`Regex: ${event.config.regex}`);
+
+    if (event.line) {
+      lines.push(`Log: ${event.line}`);
+    }
+
+    if (event.matchCount) {
+      lines.push(`Matches: ${event.matchCount}`);
+    }
+
+    lines.push(`Time: ${new Date().toISOString()}`);
+
+    return lines.join("\n");
+  }
+
+  private buildHtmlMessage(
+    event: BanEvent,
+    geo: Partial<IpInfosResponse>,
+  ): string {
+    const escapeHtml = (str: string) =>
+      str
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+
+    const countryRow = geo?.country
+      ? `
+            <tr>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6; font-weight: bold;">Country</td>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6;">${geo.country.flag} ${escapeHtml(geo.country.name)}</td>
+            </tr>`
+      : "";
+
+    const logRow = event.line
+      ? `
+            <tr>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6; font-weight: bold;">Matched Log</td>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6;"><code style="word-break: break-all;">${escapeHtml(event.line)}</code></td>
+            </tr>`
+      : "";
+
+    const matchCountRow = event.matchCount
+      ? `
+            <tr>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6; font-weight: bold;">Match Count</td>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6;">${event.matchCount}</td>
+            </tr>`
+      : "";
+
+    return `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background: #dc3545; color: white; padding: 20px; text-align: center;">
+          <h1 style="margin: 0;">IP Banned</h1>
+        </div>
+        <div style="padding: 20px; background: #f8f9fa;">
+          <table style="width: 100%; border-collapse: collapse;">
+            <tr>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6; font-weight: bold;">IP Address</td>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6;">${escapeHtml(event.ip)}</td>
+            </tr>${countryRow}
+            <tr>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6; font-weight: bold;">Configuration</td>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6;">${escapeHtml(event.config.name)}</td>
+            </tr>
+            <tr>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6; font-weight: bold;">Regex Pattern</td>
+              <td style="padding: 10px; border-bottom: 1px solid #dee2e6;"><code>${escapeHtml(event.config.regex)}</code></td>
+            </tr>${logRow}${matchCountRow}
+            <tr>
+              <td style="padding: 10px; font-weight: bold;">Timestamp</td>
+              <td style="padding: 10px;">${new Date().toISOString()}</td>
+            </tr>
+          </table>
+        </div>
+        <div style="padding: 10px; background: #e9ecef; text-align: center; font-size: 12px; color: #6c757d;">
+          Banalize Notification
+        </div>
+      </div>
+    `;
   }
 }

--- a/apps/api/src/notifications/services/notifier-manager.service.ts
+++ b/apps/api/src/notifications/services/notifier-manager.service.ts
@@ -35,10 +35,10 @@ export class NotifierManager implements OnModuleInit {
     );
   }
 
-  async notify({ type, title, message }: NotifyEvent) {
+  async notify({ type, title, message, html }: NotifyEvent) {
     this.logger.debug(`Notifying ${type} with message: ${message}`);
     for (const notifier of this.notifiers[type]) {
-      notifier.notify(new Notification(title, message));
+      notifier.notify(new Notification(title, message, html));
     }
   }
 

--- a/apps/api/src/notifications/types/notify-event.types.ts
+++ b/apps/api/src/notifications/types/notify-event.types.ts
@@ -5,5 +5,6 @@ export class NotifyEvent {
     readonly type: EventType,
     readonly title: string,
     readonly message: string,
+    readonly html?: string,
   ) {}
 }


### PR DESCRIPTION
Add comprehensive information to ban notifications including:
- IP address with geolocation (country flag + name)
- Configuration name and regex pattern
- Matched log line that triggered the ban
- Match count and timestamp

Emails now include a styled HTML template with a table layout, while Signal/text notifications use a clean multi-line format.