### PR TITLE
Adds status bar with version and health info

### DIFF
--- a/apps/core/src/api/meta.rs
+++ b/apps/core/src/api/meta.rs
@@ -1,0 +1,43 @@
+use axum::response::Json;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub(crate) struct VersionResponse {
+    /// The running core crate version (semver).
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub(crate) struct HealthResponse {
+    /// Liveness marker; always `"ok"` when the core answers.
+    pub status: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/version",
+    tag = "meta",
+    responses(
+        (status = 200, description = "Running core version", body = VersionResponse),
+    )
+)]
+pub(crate) async fn get_version() -> Json<VersionResponse> {
+    Json(VersionResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    })
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/health",
+    tag = "meta",
+    responses(
+        (status = 200, description = "Core is alive", body = HealthResponse),
+    )
+)]
+pub(crate) async fn get_health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok".to_string(),
+    })
+}

--- a/apps/core/src/api/mod.rs
+++ b/apps/core/src/api/mod.rs
@@ -6,6 +6,7 @@ mod ip_infos;
 mod ips;
 mod logs;
 mod matches;
+mod meta;
 mod notifiers;
 mod unbans;
 
@@ -71,6 +72,8 @@ pub struct AppState {
         ip_infos::get_ip_infos,
         ips::get_ip_stats,
         ips::get_country_stats,
+        meta::get_version,
+        meta::get_health,
     ),
     components(schemas(
         ConfigResponse,
@@ -88,6 +91,8 @@ pub struct AppState {
         crate::notifier::NotifyEventType,
         crate::log_capture::LogEntry,
         crate::geoip::IpInfo,
+        meta::VersionResponse,
+        meta::HealthResponse,
     )),
     tags(
         (name = "configs", description = "Configuration management"),
@@ -99,6 +104,7 @@ pub struct AppState {
         (name = "notifiers", description = "Notification channels"),
         (name = "ip-infos", description = "GeoIP country lookup"),
         (name = "ips",     description = "Per-IP aggregates"),
+        (name = "meta",    description = "Service version and health"),
     )
 )]
 pub struct ApiDoc;
@@ -165,6 +171,8 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/ip-infos", get(ip_infos::get_ip_infos))
         .route("/api/ips/stats", get(ips::get_ip_stats))
         .route("/api/ips/by-country", get(ips::get_country_stats))
+        .route("/api/version", get(meta::get_version))
+        .route("/api/health", get(meta::get_health))
         .route("/api/logs", get(logs::get_logs))
         .route("/api/logs/stream", get(logs::stream_logs))
         .route("/api/events/stream", get(events::stream_events))

--- a/apps/e2e/cases/navigation/status-bar.spec.ts
+++ b/apps/e2e/cases/navigation/status-bar.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "../../fixtures";
+
+/**
+ * The bottom status bar surfaces the UI and core versions plus a backend health
+ * dot. Against the live stack the dot is always online; we assert it reflects
+ * that and that the shown core version matches what the core reports.
+ */
+test.describe("status bar", () => {
+  test("shows the core version and an online health dot", async ({
+    api,
+    statusBar,
+  }) => {
+    let version!: string;
+
+    await test.step("Given a live core reporting its version and health", async () => {
+      // The core exposes its version and a liveness probe out-of-band.
+      ({ version } = await api.getVersion());
+      expect(version).toMatch(/^\d+\.\d+\.\d+/);
+      expect((await api.getHealth()).status).toBe("ok");
+    });
+
+    await test.step("When the UI is opened", async () => {
+      await statusBar.goto();
+    });
+
+    await test.step("Then the status bar shows both versions and an online dot", async () => {
+      await statusBar.expectCoreVersion(version);
+      await statusBar.expectUiVersion(/ui \d+\.\d+\.\d+/);
+      await statusBar.expectOnline();
+    });
+  });
+});

--- a/apps/e2e/fixtures.ts
+++ b/apps/e2e/fixtures.ts
@@ -11,12 +11,14 @@ import { MatchesDriver } from "./utils/drivers/MatchesDriver";
 import { NotificationsDriver } from "./utils/drivers/NotificationsDriver";
 import { OffendersDriver } from "./utils/drivers/OffendersDriver";
 import { SidebarDriver } from "./utils/drivers/SidebarDriver";
+import { StatusBarDriver } from "./utils/drivers/StatusBarDriver";
 import { LogInjector } from "./utils/log-injector";
 
 type Fixtures = {
   api: ApiClient;
   logInjector: LogInjector;
   sidebar: SidebarDriver;
+  statusBar: StatusBarDriver;
   dashboard: DashboardDriver;
   configs: ConfigsDriver;
   configDetail: ConfigDetailDriver;
@@ -45,6 +47,9 @@ export const test = base.extend<Fixtures>({
   },
   sidebar: async ({ page }, use) => {
     await use(new SidebarDriver(page));
+  },
+  statusBar: async ({ page }, use) => {
+    await use(new StatusBarDriver(page));
   },
   dashboard: async ({ page }, use) => {
     await use(new DashboardDriver(page));

--- a/apps/e2e/utils/api-client.ts
+++ b/apps/e2e/utils/api-client.ts
@@ -60,6 +60,14 @@ export class ApiClient {
     return res.json() as Promise<T>;
   }
 
+  getVersion(): Promise<{ version: string }> {
+    return this.json<{ version: string }>("/api/version");
+  }
+
+  getHealth(): Promise<{ status: string }> {
+    return this.json<{ status: string }>("/api/health");
+  }
+
   listConfigs(): Promise<Config[]> {
     return this.json<Config[]>("/api/configs");
   }

--- a/apps/e2e/utils/drivers/StatusBarDriver.ts
+++ b/apps/e2e/utils/drivers/StatusBarDriver.ts
@@ -1,0 +1,27 @@
+import { expect } from "@playwright/test";
+
+import { BaseDriver } from "./BaseDriver";
+
+/** Drives the bottom status bar (versions + backend health dot). */
+export class StatusBarDriver extends BaseDriver {
+  // The bar is global; any page renders it. Dashboard is the default landing.
+  protected readonly path = "/dashboard";
+
+  async expectUiVersion(version: string | RegExp): Promise<void> {
+    await expect(this.byTestId("status-bar-ui-version")).toContainText(version);
+  }
+
+  async expectCoreVersion(version: string): Promise<void> {
+    await expect(this.byTestId("status-bar-core-version")).toContainText(
+      version,
+    );
+  }
+
+  /** Assert the health dot reports the backend as online. */
+  async expectOnline(): Promise<void> {
+    await expect(this.byTestId("status-bar-dot")).toHaveAttribute(
+      "data-status",
+      "online",
+    );
+  }
+}

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import logoIcon from "@/assets/logo-icon.png";
 import MobileNav from "@/components/layout/MobileNav";
 import Sidebar from "@/components/layout/Sidebar";
+import StatusBar from "@/components/layout/StatusBar";
 import { Button } from "@/components/ui/button";
 import { DataSourceProvider, dataSource } from "@/lib/datasource";
 import { useLiveEvents } from "@/lib/use-live-events";
@@ -82,6 +83,7 @@ export default function App() {
                   <Route path="/logs" element={<LogsPage />} />
                 </Routes>
               </main>
+              <StatusBar />
             </div>
           </div>
         </BrowserRouter>

--- a/apps/ui/src/components/layout/StatusBar.tsx
+++ b/apps/ui/src/components/layout/StatusBar.tsx
@@ -1,0 +1,42 @@
+import { useStatus, type HealthState } from "@/lib/use-status";
+import { cn } from "@/lib/utils";
+
+const DOT_COLOR: Record<HealthState, string> = {
+  online: "bg-green-500",
+  offline: "bg-destructive",
+  pending: "bg-amber-500",
+};
+
+const DOT_LABEL: Record<HealthState, string> = {
+  online: "Backend online",
+  offline: "Backend offline",
+  pending: "Checking backend…",
+};
+
+/**
+ * Thin pill bar pinned to the bottom of the content column. Surfaces the UI and
+ * core versions and a health dot reflecting backend reachability.
+ */
+export default function StatusBar() {
+  const { coreVersion, health } = useStatus();
+
+  return (
+    <footer
+      data-testid="status-bar"
+      className="flex items-center gap-2 border-t bg-card px-4 py-1.5 text-xs text-muted-foreground"
+    >
+      <span
+        data-testid="status-bar-dot"
+        data-status={health}
+        title={DOT_LABEL[health]}
+        aria-label={DOT_LABEL[health]}
+        className={cn("h-2 w-2 shrink-0 rounded-full", DOT_COLOR[health])}
+      />
+      <span data-testid="status-bar-ui-version">ui {__APP_VERSION__}</span>
+      <span aria-hidden>·</span>
+      <span data-testid="status-bar-core-version">
+        core {coreVersion ?? "—"}
+      </span>
+    </footer>
+  );
+}

--- a/apps/ui/src/lib/datasource/http.ts
+++ b/apps/ui/src/lib/datasource/http.ts
@@ -146,6 +146,14 @@ export class HttpDataSource implements DataSource {
     return () => es.close();
   }
 
+  getVersion() {
+    return fetchJson<{ version: string }>("/api/version");
+  }
+
+  getHealth() {
+    return fetchJson<{ status: string }>("/api/health");
+  }
+
   getNotifiers() {
     return fetchJson<NotifierConfig[]>("/api/notifiers");
   }

--- a/apps/ui/src/lib/datasource/types.ts
+++ b/apps/ui/src/lib/datasource/types.ts
@@ -153,6 +153,10 @@ export interface DataSource {
   ): () => void;
   /** Subscribe to live match/ban/unban events. Returns an unsubscribe function. */
   streamEvents(onEvent: (event: LiveEvent) => void): () => void;
+  /** The running core version (semver). Stable for the process lifetime. */
+  getVersion(): Promise<{ version: string }>;
+  /** Liveness probe; resolves only while the core is reachable. */
+  getHealth(): Promise<{ status: string }>;
   getNotifiers(): Promise<NotifierConfig[]>;
   createNotifier(notifier: NotifierConfig): Promise<NotifierConfig>;
   updateNotifier(notifier: NotifierConfig): Promise<NotifierConfig>;

--- a/apps/ui/src/lib/use-status.ts
+++ b/apps/ui/src/lib/use-status.ts
@@ -1,0 +1,38 @@
+import { useDataSource } from "@/lib/datasource";
+import { useQuery } from "@tanstack/react-query";
+
+/** Health of the backend connection, driving the status dot. */
+export type HealthState = "online" | "offline" | "pending";
+
+/**
+ * The core version (fetched once) plus a live health signal (polled). The
+ * version never changes for the process lifetime, so it's cached forever; the
+ * health probe re-runs on an interval and its query state drives the dot.
+ */
+export function useStatus(): { coreVersion?: string; health: HealthState } {
+  const ds = useDataSource();
+
+  const { data } = useQuery({
+    queryKey: ["version"],
+    queryFn: () => ds.getVersion(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: false,
+  });
+
+  const { status } = useQuery({
+    queryKey: ["health"],
+    queryFn: () => ds.getHealth(),
+    refetchInterval: 30_000,
+    retry: false,
+  });
+
+  const health: HealthState =
+    status === "success"
+      ? "online"
+      : status === "error"
+        ? "offline"
+        : "pending";
+
+  return { coreVersion: data?.version, health };
+}

--- a/apps/ui/src/vite-env.d.ts
+++ b/apps/ui/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** The UI's package.json version, injected at build time by Vite `define`. */
+declare const __APP_VERSION__: string;

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,9 +1,17 @@
 import react from "@vitejs/plugin-react";
+import { readFileSync } from "fs";
 import path from "path";
 import { defineConfig } from "vite";
 
+const { version } = JSON.parse(
+  readFileSync(path.resolve(__dirname, "./package.json"), "utf-8"),
+) as { version: string };
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Introduces a new status bar at the bottom of the UI to provide immediate operational feedback.

- Displays the running UI application version.
- Shows the core backend service version by querying a new API endpoint.
- Presents a live health indicator (dot) reflecting the backend's reachability, polled regularly via a new API endpoint.
- Includes new API endpoints in the core service for version and health information.
- Integrates E2E tests to verify the accurate display of versions and health status.