### PR TITLE
Enhances UI event tracking and Dependabot reliability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  # Root package.json (monorepo root)
+  # npm/pnpm workspace (root + apps/* + packages/*)
+  # A single entry at the workspace root is required because the whole
+  # monorepo shares one root pnpm-lock.yaml. Per-directory entries would
+  # update the member package.json but leave the root lockfile untouched,
+  # so CI fails on the out-of-sync lockfile.
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: "main"
@@ -24,46 +28,10 @@ updates:
           - "gitmoji*"
           - "eslint*"
           - "typescript*"
-
-  # UI app
-  - package-ecosystem: "npm"
-    directory: "/apps/ui"
-    target-branch: "main"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dependencies"
-      - "npm"
-      - "ui"
-
-  # Packages
-  - package-ecosystem: "npm"
-    directory: "/packages"
-    target-branch: "main"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels:
-      - "dependencies"
-      - "npm"
-      - "packages"
-    groups:
-      dev-dependencies:
-        patterns:
-          - "eslint*"
-          - "typescript*"
           - "stylelint*"
+      radix:
+        patterns:
+          - "@radix-ui/*"
 
   # Rust/Cargo dependencies
   - package-ecosystem: "cargo"

--- a/apps/e2e/cases/bans/shrink-ban-time.spec.ts
+++ b/apps/e2e/cases/bans/shrink-ban-time.spec.ts
@@ -1,0 +1,89 @@
+import { test } from "../../fixtures";
+import { containerLogPath } from "../../utils/config";
+import { FAILED_LOGIN_REGEX } from "../../utils/log-injector";
+import {
+  MINUTE,
+  randomIp,
+  SECOND,
+  sleep,
+  uniqueSuffix,
+  WATCHER_WARMUP_MS,
+} from "../../utils/utils";
+
+/**
+ * A ban keeps the effective duration it was issued with: the backend freezes it
+ * at creation and the cleaner expires off that stored value, so editing a
+ * config's ban_time afterwards does not retroactively shorten a running ban.
+ *
+ * The UI must reflect that. It used to derive expiry from the *current* config,
+ * so cutting ban_time flipped a ban to "expired" while the backend kept it
+ * enforced and never emitted an unban — an expired-looking ban with no unban and
+ * an IP still blocked. The fix: a ban stays "active" in the UI until the backend
+ * actually records an unban.
+ */
+test.describe("ban duration shortened mid-ban", () => {
+  test("cutting ban_time below the time served keeps the ban active until the backend lifts it", async ({
+    api,
+    logInjector,
+    bans,
+  }) => {
+    test.setTimeout(60 * SECOND);
+
+    const suffix = uniqueSuffix();
+    const file = `shrink-ban-${suffix}.log`;
+    const configId = `shrink-ban-${suffix}`;
+    const name = `Shrink ban ${suffix}`;
+    const ip = randomIp();
+    const maxMatches = 3;
+
+    await test.step("Given an IP banned under a long ban_time", async () => {
+      await logInjector.create(file);
+      await api.createConfig({
+        id: configId,
+        name,
+        param: containerLogPath(file),
+        regex: FAILED_LOGIN_REGEX,
+        // Long enough that it never expires on its own during the test.
+        ban_time: 5 * MINUTE,
+        find_time: 5 * MINUTE,
+        max_matches: maxMatches,
+        ignore_ips: [],
+      });
+
+      await sleep(WATCHER_WARMUP_MS);
+      await logInjector.failedLogin(file, ip, maxMatches + 2);
+
+      await bans.goto();
+      await bans.search(ip);
+      await bans.expectStatus(ip, "active");
+    });
+
+    await test.step("When the config's ban_time is cut below the time already served", async () => {
+      await api.updateConfig({
+        id: configId,
+        name,
+        param: containerLogPath(file),
+        regex: FAILED_LOGIN_REGEX,
+        // Now far shorter than the ban that is already running.
+        ban_time: 2 * SECOND,
+        find_time: 5 * MINUTE,
+        max_matches: maxMatches,
+        ignore_ips: [],
+      });
+
+      // Give the cleaner (5s tick) a couple of cycles to act on the new
+      // duration, then reload so the UI reads the new ban_time for the badge.
+      await sleep(12 * SECOND);
+      await bans.goto();
+      await bans.search(ip);
+    });
+
+    await test.step("Then the UI still shows the ban as active, with no phantom unban", async () => {
+      // The backend froze this ban's duration at creation and recorded no
+      // unban, so the IP is still firewalled. The UI reflects that — active,
+      // not a phantom "expired" derived from the shortened config.
+      await bans.expectStatus(ip, "active");
+      await bans.expectNoUnbanRow(ip);
+    });
+  });
+});

--- a/apps/e2e/cases/events/match-status.spec.ts
+++ b/apps/e2e/cases/events/match-status.spec.ts
@@ -1,0 +1,67 @@
+import { test } from "../../fixtures";
+import { containerLogPath } from "../../utils/config";
+import { FAILED_LOGIN_REGEX } from "../../utils/log-injector";
+import {
+  MINUTE,
+  randomIp,
+  SECOND,
+  sleep,
+  uniqueSuffix,
+  WATCHER_WARMUP_MS,
+} from "../../utils/utils";
+
+/** Short window so a single match flips counting → expired within the test. */
+const FIND_TIME = 6 * SECOND;
+
+/**
+ * Each match row carries a window status telling whether it still counts toward
+ * a ban: "counting" while it sits inside the config's find_time window, then
+ * "expired" once it ages out. The badge is derived client-side from find_time,
+ * so a short window lets us watch a single sub-threshold match flip from one to
+ * the other without ever tripping a ban.
+ */
+test.describe("match window status", () => {
+  test("a match reads counting inside its find_time window, then expired once it ages out", async ({
+    api,
+    logInjector,
+    matches,
+  }) => {
+    test.setTimeout(60 * SECOND);
+
+    const suffix = uniqueSuffix();
+    const file = `match-status-${suffix}.log`;
+    const configId = `match-status-${suffix}`;
+    const ip = randomIp();
+
+    await test.step("Given a config with a short find_time and a high ban threshold", async () => {
+      await logInjector.create(file);
+      await api.createConfig({
+        id: configId,
+        name: `Match status ${suffix}`,
+        param: containerLogPath(file),
+        regex: FAILED_LOGIN_REGEX,
+        ban_time: 5 * MINUTE,
+        find_time: FIND_TIME,
+        // High enough that a single match never trips a ban — we isolate the
+        // match's own window status, not the ban flow.
+        max_matches: 5,
+        ignore_ips: [],
+      });
+      await sleep(WATCHER_WARMUP_MS);
+    });
+
+    await test.step("When the IP produces a single match", async () => {
+      await matches.goto();
+      await matches.search(ip);
+      await logInjector.failedLogin(file, ip, 1);
+    });
+
+    await test.step("Then it reads counting, then flips to expired once the window elapses", async () => {
+      // The badge tracks the find_time window off the client clock: it shows
+      // "counting" while the match is fresh, then flips to "expired" in place
+      // (the row stays — match events are kept in the durable audit log).
+      await matches.expectStatus(ip, "counting");
+      await matches.expectStatus(ip, "expired");
+    });
+  });
+});

--- a/apps/e2e/utils/drivers/MatchesDriver.ts
+++ b/apps/e2e/utils/drivers/MatchesDriver.ts
@@ -2,6 +2,8 @@ import { expect } from "@playwright/test";
 
 import { BaseDriver } from "./BaseDriver";
 
+export type MatchStatus = "counting" | "expired";
+
 /** Drives match rows on the merged Events table. */
 export class MatchesDriver extends BaseDriver {
   protected readonly path = "/events";
@@ -12,6 +14,19 @@ export class MatchesDriver extends BaseDriver {
 
   async search(query: string): Promise<void> {
     await this.byTestId("table-search").fill(query);
+  }
+
+  /**
+   * Wait for `ip`'s (first) match row to show the expected window status:
+   * "counting" while the match is inside the config's find_time window,
+   * "expired" once it ages out. Polls — matches arrive async and the badge
+   * flips client-side as the window elapses.
+   */
+  async expectStatus(ip: string, status: MatchStatus): Promise<void> {
+    await expect(this.byTestId(`matches-status-${ip}`).first()).toHaveText(
+      status,
+      { timeout: 20_000 },
+    );
   }
 
   async expectRowVisible(ip: string): Promise<void> {

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -56,7 +56,7 @@ export default function App() {
                 </Button>
                 <Logo className="h-8 w-10 shrink-0" />
                 <span className="brandWordmark text-lg font-semibold tracking-tight">
-                  banalize
+                  Banalize
                 </span>
               </header>
               <main className="flex-1 overflow-auto p-4 md:p-6">

--- a/apps/ui/src/components/events-table.tsx
+++ b/apps/ui/src/components/events-table.tsx
@@ -18,7 +18,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { type BanStatus, banStatus, effectiveBanTime } from "@/lib/ban-status";
+import {
+  type BanStatus,
+  banStatus,
+  effectiveBanTime,
+  type MatchStatus,
+  matchStatus,
+} from "@/lib/ban-status";
 import { useDataSource } from "@/lib/datasource";
 import { type Period, periodStart } from "@/lib/period";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
@@ -91,6 +97,19 @@ const statusBadge: Record<
   active: { variant: "destructive", label: "active" },
   expired: { variant: "outline", label: "expired" },
   unbanned: { variant: "secondary", label: "unbanned" },
+};
+
+const matchStatusBadge: Record<
+  MatchStatus,
+  { variant: "secondary" | "outline"; label: string; className?: string }
+> = {
+  counting: {
+    variant: "secondary",
+    label: "counting",
+    className:
+      "border-transparent bg-gradient-to-r from-brand-blue to-brand-purple text-white hover:opacity-90",
+  },
+  expired: { variant: "outline", label: "expired" },
 };
 
 interface EventsTableProps {
@@ -297,6 +316,17 @@ export default function EventsTable({
                     ? ban.timestamp + effectiveBanTime(ban, bans, banConfig)
                     : undefined;
 
+                const matchConfig =
+                  r.kind === "match" ? configMap.get(r.config_id) : undefined;
+                const mStatus =
+                  r.kind === "match"
+                    ? matchStatus(r.timestamp, matchConfig, now)
+                    : undefined;
+                const countingEnd =
+                  mStatus === "counting" && matchConfig
+                    ? r.timestamp + matchConfig.find_time
+                    : undefined;
+
                 return (
                   <Fragment key={rowKey(r)}>
                     <TableRow
@@ -339,6 +369,25 @@ export default function EventsTable({
                                 {formatDuration(
                                   Math.max(0, scheduledEnd - now),
                                 )}{" "}
+                                left
+                              </span>
+                            ) : null}
+                          </div>
+                        ) : mStatus ? (
+                          <div className="flex items-center gap-2">
+                            <Badge
+                              variant={matchStatusBadge[mStatus].variant}
+                              className={cn(
+                                "font-normal",
+                                matchStatusBadge[mStatus].className,
+                              )}
+                              data-testid={`matches-status-${r.ip}`}
+                            >
+                              {matchStatusBadge[mStatus].label}
+                            </Badge>
+                            {countingEnd !== undefined ? (
+                              <span className="text-xs tabular-nums text-muted-foreground">
+                                {formatDuration(Math.max(0, countingEnd - now))}{" "}
                                 left
                               </span>
                             ) : null}

--- a/apps/ui/src/components/events-table.tsx
+++ b/apps/ui/src/components/events-table.tsx
@@ -305,7 +305,7 @@ export default function EventsTable({
                     ? bans.find((b) => b.id === r.id)
                     : undefined;
                 const status = ban
-                  ? banStatus(ban, bans, unbans, configMap, now)
+                  ? banStatus(ban, bans, unbans, configMap)
                   : undefined;
                 const active = status === "active";
                 const banConfig = ban
@@ -364,12 +364,11 @@ export default function EventsTable({
                             >
                               {statusBadge[status].label}
                             </Badge>
-                            {active && scheduledEnd !== undefined ? (
+                            {active &&
+                            scheduledEnd !== undefined &&
+                            scheduledEnd > now ? (
                               <span className="text-xs tabular-nums text-muted-foreground">
-                                {formatDuration(
-                                  Math.max(0, scheduledEnd - now),
-                                )}{" "}
-                                left
+                                {formatDuration(scheduledEnd - now)} left
                               </span>
                             ) : null}
                           </div>

--- a/apps/ui/src/components/layout/SidebarNav.tsx
+++ b/apps/ui/src/components/layout/SidebarNav.tsx
@@ -36,7 +36,7 @@ export default function SidebarNav({ collapsed, onNavigate }: SidebarNavProps) {
           <Logo className="h-10 w-12 shrink-0" />
           {!collapsed && (
             <span className="brandWordmark text-2xl font-semibold tracking-tight">
-              banalize
+              Banalize
             </span>
           )}
         </div>

--- a/apps/ui/src/lib/ban-status.ts
+++ b/apps/ui/src/lib/ban-status.ts
@@ -2,6 +2,23 @@ import type { BanEvent, Config, UnbanEvent } from "@/lib/datasource";
 
 export type BanStatus = "active" | "expired" | "unbanned";
 
+export type MatchStatus = "counting" | "expired";
+
+/**
+ * Whether a match still counts toward triggering a ban. The backend bans an IP
+ * once `max_matches` of its matches fall within the trailing `find_time` window
+ * (see detector.rs); once a match ages past that window it no longer counts.
+ * With the config gone there is nothing left to count it for, so it's expired.
+ */
+export function matchStatus(
+  matchTimestamp: number,
+  config: Config | undefined,
+  now: number,
+): MatchStatus {
+  if (!config) return "expired";
+  return matchTimestamp + config.find_time > now ? "counting" : "expired";
+}
+
 /**
  * Effective duration of a single ban, mirroring the backend: with the recidive
  * multiplicator set, the same (config, IP) escalates as

--- a/apps/ui/src/lib/ban-status.ts
+++ b/apps/ui/src/lib/ban-status.ts
@@ -44,10 +44,13 @@ export function effectiveBanTime(
 }
 
 /**
- * Status of one ban event, mirroring the backend semantics: a ban ends when a
- * matching unban event lands at or after it (manual disable, config deletion,
- * or the cleaner expiring it) or when its ban_time elapses (shown as expired
- * even before the cleaner's next tick records the unban event).
+ * Status of one ban event, mirroring the backend semantics: a ban is enforced
+ * until the backend records a matching unban event (manual disable, config
+ * deletion, or the cleaner expiring it). Crucially, the UI does *not* declare a
+ * ban expired on its own once the config's ban_time elapses: a ban keeps the
+ * effective duration it was issued with, which the backend froze at creation,
+ * so a later edit to the config's ban_time must not retroactively "expire" a
+ * still-enforced ban here. Only the unban event ends a ban.
  *
  * `bans` is the full ban list, needed to size escalated (recidive) bans.
  */
@@ -56,7 +59,6 @@ export function banStatus(
   bans: BanEvent[],
   unbans: UnbanEvent[],
   configs: Map<string, Config>,
-  now: number,
 ): BanStatus {
   const config = configs.get(ban.config_id);
   const scheduledEnd = config
@@ -79,8 +81,9 @@ export function banStatus(
     return "unbanned";
   }
 
-  if (scheduledEnd !== undefined && scheduledEnd <= now) return "expired";
-  // Config gone and no unban event: nothing enforces this ban anymore.
+  // Config gone but no unban yet: deletion lifts every ban and emits an unban
+  // (see api/configs.rs), so this only covers the brief load race before that
+  // unban arrives — nothing enforces the ban anymore.
   if (!config) return "expired";
   return "active";
 }
@@ -91,9 +94,8 @@ export function isIpBanned(
   bans: BanEvent[],
   unbans: UnbanEvent[],
   configs: Map<string, Config>,
-  now: number,
 ): boolean {
   return bans.some(
-    (b) => b.ip === ip && banStatus(b, bans, unbans, configs, now) === "active",
+    (b) => b.ip === ip && banStatus(b, bans, unbans, configs) === "active",
   );
 }

--- a/apps/ui/src/lib/use-live-events.ts
+++ b/apps/ui/src/lib/use-live-events.ts
@@ -16,31 +16,39 @@ const THROTTLE_MS = 1_000;
  * affected queries so every page refreshes without polling. Invalidations
  * are throttled (leading + trailing) because an attack burst can emit
  * hundreds of match events per second.
+ *
+ * Both edges fire every window: the leading edge keeps live updates snappy,
+ * and the trailing edge re-fetches once more ~THROTTLE_MS later. The trailing
+ * refetch is essential, not just coalescing — a match's SSE event is emitted
+ * before its durable audit-log write lands, so the leading refetch alone can
+ * read stale (empty) data and, with no further events, never correct itself.
  */
 export function useLiveEvents() {
   const ds = useDataSource();
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    const pending = new Set<string>();
+    let keys = new Set<string>();
     let timer: ReturnType<typeof setTimeout> | undefined;
 
-    const flush = () => {
-      timer = undefined;
-      pending.forEach((key) => {
+    const invalidate = () => {
+      keys.forEach((key) => {
         void queryClient.invalidateQueries({ queryKey: [key] });
       });
-      pending.clear();
     };
 
     const unsubscribe = ds.streamEvents((event) => {
-      const keys = AFFECTED_KEYS[event.kind];
-      if (!keys) return;
-      keys.forEach((key) => pending.add(key));
-      if (timer === undefined) {
-        flush();
-        timer = setTimeout(flush, THROTTLE_MS);
-      }
+      const affected = AFFECTED_KEYS[event.kind];
+      if (!affected) return;
+      affected.forEach((key) => keys.add(key));
+      if (timer !== undefined) return;
+
+      invalidate(); // leading edge
+      timer = setTimeout(() => {
+        timer = undefined;
+        invalidate(); // trailing edge
+        keys = new Set();
+      }, THROTTLE_MS);
     });
 
     return () => {

--- a/apps/ui/src/pages/OffendersPage.tsx
+++ b/apps/ui/src/pages/OffendersPage.tsx
@@ -14,7 +14,6 @@ import { type IpStats, useDataSource } from "@/lib/datasource";
 import { type Period, periodStart } from "@/lib/period";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { useIpInfos } from "@/lib/use-ip-infos";
-import { useNow } from "@/lib/use-now";
 import { formatTimestamp } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowDown, ArrowUp } from "lucide-react";
@@ -66,7 +65,6 @@ export default function OffendersPage() {
     refetchInterval: 60_000,
   });
 
-  const now = useNow(1000);
   const configMap = new Map(configs.map((c) => [c.id, c]));
 
   const query = search.trim().toLowerCase();
@@ -166,7 +164,7 @@ export default function OffendersPage() {
               </TableRow>
             ) : (
               visible.map((s) => {
-                const banned = isIpBanned(s.ip, bans, unbans, configMap, now);
+                const banned = isIpBanned(s.ip, bans, unbans, configMap);
                 return (
                   <TableRow
                     key={s.ip}


### PR DESCRIPTION
**Summary:**
This pull request significantly enhances the user interface's event tracking and management, particularly regarding ban and match statuses, while also rectifying Dependabot's behavior in pnpm monorepo setups. The UI now accurately reflects ban durations as enforced by the backend and provides clear visibility into match event relevancy.

**Impact:**
- **Correct Ban Status:** Resolves a critical UI bug where bans could appear "expired" prematurely after a config's `ban_time` was shortened, leading to discrepancies with the backend's enforcement. Bans now remain "active" in the UI until the backend explicitly lifts them.
- **Enhanced Match Visibility:** Users can now easily see which match events are still "counting" towards a ban threshold and which have "expired" from the `find_time` window.
- **Reliable Dependency Updates:** Ensures Dependabot consistently updates the `pnpm-lock.yaml` file in the monorepo, preventing CI failures due to out-of-sync lockfiles.
- **Improved Responsiveness:** Live event updates are now more robust and timely.

**Changes:**
- Updates the UI's `banStatus` logic to reflect the backend's behavior, where a ban's duration is frozen at creation and only ends upon an explicit unban event.
- Implements a `matchStatus` function and integrates it into the events table, displaying "counting" or "expired" badges for match entries.
- Refactors Dependabot configuration to use a single `npm` entry at the monorepo root, ensuring correct `pnpm-lock.yaml` updates and adds a Radix UI dependency group.
- Refines the live event invalidation mechanism with a throttled leading/trailing edge strategy for improved data consistency and responsiveness.
- Capitalizes the "Banalize" wordmark across the UI for consistent branding.
- Updates `@radix-ui/react-dialog` to version `1.1.1`.

**Tests:**
- Adds dedicated E2E tests for the new ban status logic and match window status feature.

**Checklist:**
- [x] Code changes are tested
- [ ] Documentation is updated
- [ ] Release notes are updated
- [x] New E2E tests are added